### PR TITLE
Time strings support and readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.sqlite3
+__pycache__
+.vscode

--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # PADKP-server
 Simple DKP display and CRUD operations
+
+
+##Development Instructions
+(On windows)
+* Install Python 3.7 and pip.
+* python -m pip install Django
+* python -m pip install djangorestframework
+* from powershell or other tty (gitbash doesn't play nice here)
+  * py manage.py migrate
+  * py manage.py createsuperuser (provide username, email, and password for a local admin account)
+  * py manage.py runserver
+* login to localhost:8000/admin
+

--- a/padkp_server/settings.py
+++ b/padkp_server/settings.py
@@ -25,7 +25,7 @@ SECRET_KEY = '$akk$k%-08x!s4q**b^ojx1qc_$1*t8a7w!!%!xy587pqgp82i'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ['padkp', 'padkp.net']
+ALLOWED_HOSTS = ['padkp', 'padkp.net', 'localhost']
 
 
 # Application definition

--- a/padkp_show/models.py
+++ b/padkp_show/models.py
@@ -46,7 +46,7 @@ class RaidDump(models.Model):
 
     def __str__(self):
         attendance_str = '' if self.attendance_value else " (not counted for attendance)"
-        time_str = self.time.astimezone(pytz.timezone('US/Eastern')).strftime('%A, %d %b %Y %l:%M %p Eastern')
+        time_str = self.time.astimezone(pytz.timezone('US/Eastern')).strftime('%A, %d %b %Y %I:%M %p Eastern')
         return '{} for {} on {}{}'.format(self.value, self.award_type, time_str, attendance_str)
 
 
@@ -65,7 +65,7 @@ class DkpSpecialAward(models.Model):
 
     def __str__(self):
         attendance_str = '' if self.attendance_value else " (not counted for attendance)"
-        time_str = self.time.astimezone(pytz.timezone('US/Eastern')).strftime('%A, %d %b %Y %l:%M %p Eastern')
+        time_str = self.time.astimezone(pytz.timezone('US/Eastern')).strftime('%A, %d %b %Y %I:%M %p Eastern')
         return '{} to {} on {}{}'.format(self.value, self.character, time_str, attendance_str)
 
 


### PR DESCRIPTION
The timestrings were using the `%l` flag which
isn't supported by python in non unix environments
so I changed it to the `%I` flag which should be the
same value but cross platform. I added localhost to
the allowed host list, similar to the debug flag
in an ideal world this is removed before deploying
the actual site.

Also updated the readme with basic operation
instructions for developers new to Django.